### PR TITLE
Fix duplicated duties

### DIFF
--- a/NOTED/NOTED.csproj
+++ b/NOTED/NOTED.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup Label="Target">
 		<PlatformTarget>x64</PlatformTarget>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Platforms>x64</Platforms>
 		<Configurations>Debug;Release</Configurations>

--- a/NOTED/Windows/SettingsWindow.cs
+++ b/NOTED/Windows/SettingsWindow.cs
@@ -38,8 +38,17 @@ namespace NOTED.Windows
             ExcelSheet<TerritoryType>? sheet = Plugin.DataManager.GetExcelSheet<TerritoryType>();
             if (sheet != null)
             {
-                List<TerritoryType> territories = sheet.Where(row => row.ContentFinderCondition.Value != null && row.ContentFinderCondition.Value.Name.ToString().Length > 0 && row.RowId != kMaskedCarnivaleID).ToList();
-                _duties = territories.Select(territory => new DutyData(territory)).ToList();
+                // Remove duplicated duties and keep the one with the higher id (newer version)
+                _duties = sheet.Where(
+                    row => row.ContentFinderCondition.Value != null &&
+                    row.ContentFinderCondition.Value.Name.ToString().Length > 0 &&
+                    row.RowId != kMaskedCarnivaleID)
+                .Select(territory => new DutyData(territory))
+                .GroupBy(duty => duty.Name)
+                .Select(duties => duties.MaxBy(duty => duty.ID))
+                .OfType<DutyData>()
+                .ToList();
+
                 _duties.Add(new DutyData("The Masked Carnivale", 796));
             }
 

--- a/NOTED/packages.lock.json
+++ b/NOTED/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net7.0": {
+    "net8.0": {
       "DalamudPackager": {
         "type": "Direct",
         "requested": "[2.1.12, )",


### PR DESCRIPTION
Hey! here's a small PR that should fix the duties that show up as duplicated.

The game has them twice, and I think that is caused because they reworked them with a new territory ID, but they don't remove the old one, they only update the duty finder constraints to point to the new one.

The fix assumes the newer duty will have a higher number. I tested it with Ala Migho and it seems ok!

I think this is also the root cause of https://github.com/Tischel/NOTED/issues/6

There is also a net8 bump in there as I found no issues.

Thanks for the plugin!