### PR TITLE
Fix right click to edit not working when not in duty

### DIFF
--- a/NOTED/Plugin.cs
+++ b/NOTED/Plugin.cs
@@ -160,7 +160,9 @@ namespace NOTED
         {
             if (note == null) { return; }
 
-            if (Settings.Duties.TryGetValue(ClientState.TerritoryType, out Duty? duty) && duty != null)
+            ushort territory = IsInDuty() ? ClientState.TerritoryType : NoDutyID();
+
+            if (Settings.Duties.TryGetValue(territory, out Duty? duty) && duty != null)
             {
                 if (duty.Notes.Contains(note))
                 {
@@ -169,6 +171,10 @@ namespace NOTED
                     _settingsWindow.NeedsFocus = true;
                     _settingsWindow.IsOpen = true;
                 }
+            }
+            else
+            {
+                Logger.Error("Duty is null for TerritoryType {TerritoryType}", territory);
             }
         }
 


### PR DESCRIPTION
Right clicking the note window to edit the note does not work when not in a duty, because it will not find the "No Duty" duty.
Might be prettier to move `ushort territory = IsInDuty() ? ClientState.TerritoryType : NoDutyID();` to a helper func or global getter as it exists in multiple places. 